### PR TITLE
Fixed hasOne/hasMany example reference to use fully-qualitied

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ App.Post = EmberGraph.Model.extend({
 		readOnly: true
 	}),
 
-	author: hasOne({
+	author: EmberGraph.hasOne({
 		relatedType: 'user',
 		inverse: 'posts'
 	}),
 
-	tags: hasMany({
+	tags: EmberGraph.hasMany({
 		relatedType: 'tag',
 		inverse: null,
 		defaultValue: ['1', '2']


### PR DESCRIPTION
All the other examples show it using the fully-qualified path. In the code as-is, there is no locally scoped `hasOne` or `hasMany`..it was probably copy-pasta from code that had `var hasOne = EmberGraph.hasOne;` etc.
